### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Introduction
 txcosm is a Python Twisted package implementing the v2 Cosm ([API](https://cosm.com/docs/v2/>). Use txcosm to integrate non blocking access to the Cosm API into your Python Twisted application.
 
-![PyPi version](https://pypip.in/v/txcosm/badge.png) &nbsp;&nbsp; ![PyPi version](https://pypip.in/d/txcosm/badge.png)
+![PyPi version](https://img.shields.io/pypi/v/txcosm.svg) &nbsp;&nbsp; ![PyPi version](https://img.shields.io/pypi/dm/txcosm.svg)
 
 ## Background
 Cosm was once known as Pachube. This package originated as _txpachube_. It has been renamed to mirror the new site name and development continues in this repository.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20txcosm))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `txcosm`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.